### PR TITLE
Update PyPI links to point to this fork of the repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/MIC-DKFZ/nnUNet"
-repository = "https://github.com/MIC-DKFZ/nnUNet"
+homepage = "https://github.com/spinalcordtoolbox/nnUNet-neuropoly"
+repository = "https://github.com/spinalcordtoolbox/nnUNet-neuropoly"
 
 [project.scripts]
 nnUNetv2_plan_and_preprocess = "nnunetv2.experiment_planning.plan_and_preprocess_entrypoints:plan_and_preprocess_entry"


### PR DESCRIPTION
These links end up on https://pypi.org/project/nnunetv2-neuropoly/ when a new release is published.

(In contrast with #2, this PR is for the `neuropoly-fork-patches` branch.)